### PR TITLE
feat: add version flag and CI auto-release bumping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,72 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Syntax check
+        run: bash -n pingsweep
+
+      - name: Version flag
+        run: |
+          ./pingsweep --version | grep -q '^pingsweep [0-9]\+\.[0-9]\+\.[0-9]\+$'
+          ./pingsweep -v | grep -q '^pingsweep [0-9]\+\.[0-9]\+\.[0-9]\+$'
+
+      - name: Help flag
+        run: ./pingsweep --help | grep -q 'Usage: pingsweep'
+
+      - name: Dry-run smoke test
+        run: |
+          ./pingsweep -n -q 127.0.0.1/32 | grep -q '^127\.0\.0\.1$'
+
+  release:
+    if: >-
+      github.event_name == 'push'
+      && github.ref == 'refs/heads/main'
+      && !contains(github.event.head_commit.message, '[skip ci]')
+      && !startsWith(github.event.head_commit.message, 'chore(release):')
+    needs: validate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Determine next version
+        id: bump
+        run: |
+          chmod +x scripts/bump-version.sh
+          scripts/bump-version.sh >> "$GITHUB_OUTPUT"
+
+      - name: Create initial tag
+        if: steps.bump.outputs.action == 'initial_tag'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "${{ steps.bump.outputs.tag }}" -m "Release ${{ steps.bump.outputs.tag }}"
+          git push origin "${{ steps.bump.outputs.tag }}"
+
+      - name: Commit version bump and tag
+        if: steps.bump.outputs.bumped == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add pingsweep
+          git commit -m "chore(release): bump version to ${{ steps.bump.outputs.version }} [skip ci]"
+          git tag -a "${{ steps.bump.outputs.tag }}" -m "Release ${{ steps.bump.outputs.tag }}"
+          git push origin main
+          git push origin "${{ steps.bump.outputs.tag }}"

--- a/pingsweep
+++ b/pingsweep
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+PINGSWEEP_VERSION="1.0.0"
+
 # Disable job control to prevent job messages
 set +m
 
@@ -29,9 +31,6 @@ check_requirements() {
     exit 1
   fi
 }
-
-# Run requirements check
-check_requirements
 
 # Function to perform DNS lookup with stderr redirection
 dns_lookup() {
@@ -95,6 +94,10 @@ while [[ $# -gt 0 ]]; do
       filter="$2"
       shift 2
       ;;
+    -v|--version)
+      echo "pingsweep $PINGSWEEP_VERSION"
+      exit 0
+      ;;
     -h|--help)
       echo "Usage: pingsweep [options] <CIDR subnet>"
       echo "Options:"
@@ -104,6 +107,7 @@ while [[ $# -gt 0 ]]; do
       echo "  -q, --quiet            Quiet mode - suppress progress output"
       echo "  -n, --dry-run          Show IPs that would be scanned without scanning"
       echo "  -s, --search SEARCH   Search/filter output (supports substring, wildcards, or regex with re: prefix)"
+      echo "  -v, --version         Show version information"
       echo "  -h, --help            Show this help message"
       echo "Example: pingsweep 192.168.1.0/24"
       echo "         pingsweep -f json 192.168.1.0/24"
@@ -118,6 +122,8 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+check_requirements
 
 # Validate format
 if [[ "$format" != "text" && "$format" != "json" && "$format" != "yaml" && "$format" != "csv" ]]; then

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Bump PINGSWEEP_VERSION in pingsweep using conventional commits since the last tag.
+#
+# Semver rules (highest matching bump wins):
+#   major - BREAKING CHANGE footer or type! scope (e.g. feat!:)
+#   minor - feat:
+#   patch - fix:, perf:, refactor:, revert:, or any other non-release commit
+#
+# Outputs (for GitHub Actions):
+#   bumped=true|false
+#   version=X.Y.Z
+#   tag=vX.Y.Z
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$ROOT/pingsweep"
+
+current_version() {
+  grep -m1 '^PINGSWEEP_VERSION=' "$SCRIPT" | sed -E 's/^PINGSWEEP_VERSION="([^"]+)".*/\1/'
+}
+
+set_version() {
+  local version="$1"
+  sed -i.bak -E "s/^PINGSWEEP_VERSION=\"[^\"]+\"/PINGSWEEP_VERSION=\"${version}\"/" "$SCRIPT"
+  rm -f "${SCRIPT}.bak"
+}
+
+CURRENT="$(current_version)"
+LAST_TAG="$(git -C "$ROOT" describe --tags --abbrev=0 --match 'v*' 2>/dev/null || true)"
+
+if [[ -z "$LAST_TAG" ]]; then
+  {
+    echo "bumped=false"
+    echo "version=${CURRENT}"
+    echo "tag=v${CURRENT}"
+    echo "action=initial_tag"
+  }
+  echo "No release tag found; tag v${CURRENT} without changing the script." >&2
+  exit 0
+fi
+
+BASE_VERSION="${LAST_TAG#v}"
+COMMITS="$(git -C "$ROOT" log "${LAST_TAG}..HEAD" --pretty=format:%s --no-merges \
+  | grep -Ev '^chore\(release\):' || true)"
+
+if [[ -z "$COMMITS" ]]; then
+  {
+    echo "bumped=false"
+    echo "version=${CURRENT}"
+    echo "tag=v${CURRENT}"
+    echo "action=none"
+  }
+  echo "No releasable commits since ${LAST_TAG}." >&2
+  exit 0
+fi
+
+bump_major=0
+bump_minor=0
+bump_patch=0
+
+while IFS= read -r subject; do
+  [[ -z "$subject" ]] && continue
+
+  if [[ "$subject" =~ BREAKING[[:space:]]CHANGE ]] || [[ "$subject" =~ ^[a-zA-Z]+(\([^)]+\))?!: ]]; then
+    bump_major=1
+  elif [[ "$subject" =~ ^feat(\([^)]+\))?: ]]; then
+    bump_minor=1
+  elif [[ "$subject" =~ ^(fix|perf|refactor|revert)(\([^)]+\))?: ]]; then
+    bump_patch=1
+  else
+    bump_patch=1
+  fi
+done <<< "$COMMITS"
+
+IFS=. read -r major minor patch <<< "$BASE_VERSION"
+major="${major:-0}"
+minor="${minor:-0}"
+patch="${patch:-0}"
+
+if (( bump_major )); then
+  NEW_VERSION="$((major + 1)).0.0"
+elif (( bump_minor )); then
+  NEW_VERSION="${major}.$((minor + 1)).0"
+else
+  NEW_VERSION="${major}.${minor}.$((patch + 1))"
+fi
+
+if [[ "$NEW_VERSION" == "$CURRENT" && "$LAST_TAG" == "v${CURRENT}" ]]; then
+  {
+    echo "bumped=false"
+    echo "version=${CURRENT}"
+    echo "tag=v${CURRENT}"
+    echo "action=none"
+  }
+  echo "Version already at ${CURRENT} for ${LAST_TAG}." >&2
+  exit 0
+fi
+
+set_version "$NEW_VERSION"
+
+{
+  echo "bumped=true"
+  echo "version=${NEW_VERSION}"
+  echo "tag=v${NEW_VERSION}"
+  echo "action=bump"
+}
+echo "Bumped ${BASE_VERSION} -> ${NEW_VERSION} based on commits since ${LAST_TAG}." >&2


### PR DESCRIPTION
## Summary
- Add `PINGSWEEP_VERSION` and `-v`/`--version` to print the current release (exits before dependency checks)
- Add `scripts/bump-version.sh` to compute semver bumps from conventional commits since the last `v*` tag
- Add GitHub Actions CI: syntax/help/version smoke tests on PRs, auto-tag on first merge to `main`, then auto-bump + tag on subsequent merges

## Version bump rules
| Commits since last tag | Bump |
|---|---|
| `BREAKING CHANGE` or `type!:` | major |
| `feat:` | minor |
| `fix:`, `perf:`, `refactor:`, `revert:`, or other | patch |

Release commits use `[skip ci]` to avoid workflow loops.

## Test plan
- [x] `bash -n pingsweep`
- [x] `./pingsweep --version` and `./pingsweep -v` print `pingsweep 1.0.0`
- [x] `./scripts/bump-version.sh` reports `action=initial_tag` when no tags exist
- [ ] Merge to `main` and confirm CI tags `v1.0.0`
- [ ] Follow-up merge with a `fix:` commit confirms bump to `1.0.1`


Made with [Cursor](https://cursor.com)