### PR TITLE
fix: CI workflow and configurable IPv6 subnet maps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,16 @@ jobs:
           ./pingsweep -v | grep -q '^pingsweep [0-9]\+\.[0-9]\+\.[0-9]\+$'
 
       - name: Help flag
-        run: ./pingsweep --help | grep -q 'Usage: pingsweep'
+        run: './pingsweep --help | grep -q "Usage: pingsweep"'
 
       - name: Dry-run smoke test
         run: |
           ./pingsweep -n -q 127.0.0.1/32 | grep -q '^127\.0\.0\.1$'
+
+      - name: IPv6 map dry-run smoke test
+        run: |
+          printf '192.168.1.0/24\t2601:441:8483:b500\n' > /tmp/pingsweep-ipv6-map
+          ./pingsweep -n -q --v6 --v6-map /tmp/pingsweep-ipv6-map 192.168.1.0/30 | grep -q '2601:441:8483:b500::'
 
   release:
     if: >-

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ This copies the script to `~/.local/bin/pingsweep`, adds a wrapper to `~/.zshfun
   -n, --dry-run          List IPs without scanning
   -s, --search PATTERN   Filter output (substring, wildcards, or re:regex)
       --v6               Parallel aligned IPv6 probes and DNS alignment checks
+      --v6-map FILE      IPv4-CIDR to IPv6-/64 map file (see README)
   -v, --version          Show version
   -h, --help             Show help
 ```
@@ -85,6 +86,36 @@ Dry-run shows aligned targets:
 ```bash
 pingsweep -n --v6 10.0.2.0/29
 ```
+
+### IPv6 map (non-standard subnets)
+
+Auto `--v6` mode derives the IPv6 `/64` from **this host’s** addresses and assumes IPv4 subnets look like `10.0.VLAN.0/CIDR`, where the VLAN digit is encoded in the fourth IPv6 hextet (`b502` = VLAN 2, `b508` = VLAN 8).
+
+Some sites have **exceptions** — for example VLAN 1 on `192.168.1.0/24` with IPv6 `2601:441:8483:b500::/64` instead of `10.0.1.0/24`. Add a user-space map so `--v6` still aligns `::N` from the last IPv4 octet.
+
+**Map file format** (whitespace-separated, `#` comments):
+
+```
+192.168.1.0/24  2601:441:8483:b500
+```
+
+**Lookup order:**
+
+1. `--v6-map /path/to/file`
+2. `$PINGSWEEP_IPV6_MAP`
+3. `$XDG_CONFIG_HOME/pingsweep/ipv6-map`
+4. `~/.config/pingsweep/ipv6-map`
+
+Copy `examples/ipv6-map.example` as a starting point:
+
+```bash
+mkdir -p ~/.config/pingsweep
+cp examples/ipv6-map.example ~/.config/pingsweep/ipv6-map
+# edit entries for your site
+pingsweep --v6 192.168.1.0/24
+```
+
+Host-id alignment is unchanged: `192.168.1.4` probes `2601:441:8483:b500::4`. Wrappers that translate VLAN numbers to CIDR (e.g. `sweep 1 --v6` → `192.168.1.0/24`) work once the map entry exists.
 
 ## Examples
 

--- a/examples/ipv6-map.example
+++ b/examples/ipv6-map.example
@@ -1,0 +1,22 @@
+# IPv6 alignment map for pingsweep --v6
+#
+# One mapping per line:
+#   <IPv4-CIDR>  <IPv6-/64-base>
+#
+# IPv4 CIDR is the subnet you scan (network form recommended).
+# IPv6 base is four hextets only (no ::/64 suffix). Host-id is still the
+# last IPv4 octet: 192.168.1.4 -> {base}::4
+#
+# Lookup order:
+#   1. --v6-map FILE
+#   2. $PINGSWEEP_IPV6_MAP
+#   3. $XDG_CONFIG_HOME/pingsweep/ipv6-map
+#   4. ~/.config/pingsweep/ipv6-map
+#
+# If no map entry matches, pingsweep falls back to auto mode for 10.0.VLAN.0/CIDR.
+
+# VLAN 1: legacy RFC1918 prefix (not 10.0.1.0/24) with its own /64
+192.168.1.0/24  2601:441:8483:b500
+
+# Example: guest Wi-Fi on a non-standard IPv4 plan
+# 172.16.50.0/24  2601:441:8483:b550

--- a/pingsweep
+++ b/pingsweep
@@ -120,6 +120,145 @@ extract_prefix64_base() {
 }
 
 ipv6_scan_iface=""
+ipv6_map_file=""
+
+normalize_ipv4_cidr() {
+  local subnet="$1" ip_part="${subnet%/*}" cidr="${subnet#*/}"
+  local ip1 ip2 ip3 ip4
+  IFS=. read -r ip1 ip2 ip3 ip4 <<< "$ip_part"
+  local host_bits=$((32 - cidr))
+  local num_hosts=$((2 ** host_bits))
+  local base=$((ip1 * 16777216 + ip2 * 65536 + ip3 * 256 + ip4))
+  base=$(( base & ~(num_hosts - 1) ))
+  printf '%d.%d.%d.%d/%s\n' \
+    $((base / 16777216)) \
+    $(((base % 16777216) / 65536)) \
+    $(((base % 65536) / 256)) \
+    $((base % 256)) \
+    "$cidr"
+}
+
+validate_ipv6_prefix64_base() {
+  [[ "$1" =~ ^([0-9a-fA-F]{1,4}:){3}[0-9a-fA-F]{1,4}$ ]]
+}
+
+ipv6_map_config_paths() {
+  if [[ -n "$ipv6_map_file" ]]; then
+    printf '%s\n' "$ipv6_map_file"
+    return 0
+  fi
+  [[ -n "${PINGSWEEP_IPV6_MAP:-}" ]] && printf '%s\n' "$PINGSWEEP_IPV6_MAP"
+  [[ -n "${XDG_CONFIG_HOME:-}" ]] && printf '%s\n' "${XDG_CONFIG_HOME}/pingsweep/ipv6-map"
+  printf '%s\n' "${HOME}/.config/pingsweep/ipv6-map"
+}
+
+# Return configured /64 base (four hextets) when scan CIDR matches a map entry.
+ipv6_map_lookup() {
+  local scan_cidr="$1"
+  local normalized_scan map_path line entry_cidr prefix normalized_entry
+
+  normalized_scan=$(normalize_ipv4_cidr "$scan_cidr")
+
+  while IFS= read -r map_path; do
+    [[ -n "$map_path" && -f "$map_path" ]] || continue
+    while IFS= read -r line || [[ -n "$line" ]]; do
+      line="${line%%#*}"
+      line="${line#"${line%%[![:space:]]*}"}"
+      [[ -z "$line" ]] && continue
+      entry_cidr="${line%%[[:space:]]*}"
+      prefix="${line#"$entry_cidr"}"
+      prefix="${prefix#"${prefix%%[![:space:]]*}"}"
+      [[ -n "$entry_cidr" && -n "$prefix" ]] || continue
+      if [[ ! "$entry_cidr" =~ ^[0-9]{1,3}(\.[0-9]{1,3}){3}/[0-9]{1,2}$ ]]; then
+        echo "Warning: skipping invalid IPv4 CIDR in IPv6 map ($map_path): $entry_cidr" >&2
+        continue
+      fi
+      if ! validate_ipv6_prefix64_base "$prefix"; then
+        echo "Warning: skipping invalid IPv6 prefix in IPv6 map ($map_path): $prefix" >&2
+        continue
+      fi
+      normalized_entry=$(normalize_ipv4_cidr "$entry_cidr")
+      if [[ "$normalized_scan" == "$normalized_entry" ]]; then
+        printf '%s\n' "$(printf '%s' "$prefix" | tr 'A-F' 'a-f')"
+        return 0
+      fi
+    done < "$map_path"
+  done < <(ipv6_map_config_paths)
+
+  return 1
+}
+
+find_scan_iface_for_subnet() {
+  local cidr="$1"
+  local probe_ip="${cidr%/*}"
+  local match_iface="" iface ipv4_addr v6_cidr
+
+  ipv6_scan_iface=""
+  if [[ "$probe_ip" == 127.* ]]; then
+    return 1
+  fi
+
+  case "$(uname -s)" in
+    Darwin|*BSD*)
+      for iface in $(ifconfig -l 2>/dev/null); do
+        [[ "$iface" == lo* ]] && continue
+        ipv4_addr=$(ifconfig "$iface" 2>/dev/null | awk '/inet [0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/ && $2 != "127.0.0.1" {print $2; exit}')
+        if [[ -n "$ipv4_addr" ]] && ipv4_in_subnet "$ipv4_addr" "$cidr"; then
+          match_iface="$iface"
+          break
+        fi
+      done
+      if [[ -z "$match_iface" ]]; then
+        match_iface=$(route -n get -inet "$probe_ip" 2>/dev/null | awk '/interface:/{print $2}')
+        [[ "$match_iface" == lo* ]] && match_iface=""
+      fi
+      if [[ -n "$match_iface" ]]; then
+        IFS=$'\t' read -r v6_cidr ipv4_addr < <(iface_ipv6_cidr "$match_iface") || v6_cidr=""
+        ipv6_scan_iface="$match_iface"
+      fi
+      if [[ -z "$ipv6_scan_iface" ]]; then
+        for iface in $(ifconfig -l 2>/dev/null); do
+          [[ "$iface" == lo* ]] && continue
+          if IFS=$'\t' read -r v6_cidr ipv4_addr < <(iface_ipv6_cidr "$iface"); then
+            ipv6_scan_iface="$iface"
+            break
+          fi
+        done
+      fi
+      ;;
+    Linux)
+      while IFS= read -r line; do
+        iface=$(awk '{print $2}' <<< "$line" | sed 's/:$//')
+        [[ "$iface" == lo* ]] && continue
+        ipv4_addr=$(awk '{print $4}' <<< "$line" | cut -d/ -f1)
+        if [[ -n "$ipv4_addr" && "$ipv4_addr" != "127.0.0.1" ]] && ipv4_in_subnet "$ipv4_addr" "$cidr"; then
+          match_iface="$iface"
+          break
+        fi
+      done < <(ip -4 -o addr show scope global 2>/dev/null)
+      if [[ -z "$match_iface" ]]; then
+        match_iface=$(ip route get "$probe_ip" 2>/dev/null | awk '/dev/{for(i=1;i<=NF;i++) if($i=="dev"){print $(i+1); exit}}')
+        [[ "$match_iface" == lo* ]] && match_iface=""
+      fi
+      if [[ -n "$match_iface" ]]; then
+        IFS=$'\t' read -r v6_cidr ipv4_addr < <(iface_ipv6_cidr "$match_iface") || v6_cidr=""
+        ipv6_scan_iface="$match_iface"
+      fi
+      if [[ -z "$ipv6_scan_iface" ]]; then
+        while IFS= read -r line; do
+          iface=$(awk '{print $2}' <<< "$line" | sed 's/:$//')
+          [[ "$iface" == lo* ]] && continue
+          if IFS=$'\t' read -r v6_cidr ipv4_addr < <(iface_ipv6_cidr "$iface"); then
+            ipv6_scan_iface="$iface"
+            break
+          fi
+        done < <(ip -6 -o addr show scope global 2>/dev/null)
+      fi
+      ;;
+  esac
+
+  [[ -n "$ipv6_scan_iface" ]]
+}
 
 # Read global /64 + IPv4 from an interface (best-effort).
 iface_ipv6_cidr() {
@@ -143,80 +282,33 @@ iface_ipv6_cidr() {
 find_local_ipv6_context() {
   local cidr="$1"
   local probe_ip="${cidr%/*}"
-  local match_iface="" iface ipv4_addr v6_cidr prefix_base
+  local v6_cidr="" prefix_base mapped_prefix
   local net_o1 net_o2 target_vlan h1 h2 h3 h4 stem hextet_len
 
-  ipv6_scan_iface=""
   if [[ "$probe_ip" == 127.* ]]; then
     return 1
   fi
 
+  ipv6_prefix_from_map=false
+  find_scan_iface_for_subnet "$cidr" || true
+
+  if mapped_prefix=$(ipv6_map_lookup "$cidr"); then
+    ipv6_prefix_from_map=true
+    ipv6_prefix64="$mapped_prefix"
+    return 0
+  fi
+
   IFS=. read -r net_o1 net_o2 target_vlan _ <<< "$probe_ip"
   if [[ "$net_o1" != "10" || "$net_o2" != "0" ]] || [[ -z "$target_vlan" ]]; then
-    echo "Error: --v6 aligned prefix expects 10.0.VLAN.0/CIDR (got ${cidr})" >&2
+    echo "Error: --v6 has no auto-aligned prefix for ${cidr}" >&2
+    echo "Add a mapping in ~/.config/pingsweep/ipv6-map (or set PINGSWEEP_IPV6_MAP / --v6-map)." >&2
+    echo "Auto mode expects 10.0.VLAN.0/CIDR where VLAN matches the IPv6 hextet digit." >&2
     return 1
   fi
 
-  case "$(uname -s)" in
-    Darwin|*BSD*)
-      for iface in $(ifconfig -l 2>/dev/null); do
-        [[ "$iface" == lo* ]] && continue
-        ipv4_addr=$(ifconfig "$iface" 2>/dev/null | awk '/inet [0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/ && $2 != "127.0.0.1" {print $2; exit}')
-        if [[ -n "$ipv4_addr" ]] && ipv4_in_subnet "$ipv4_addr" "$cidr"; then
-          match_iface="$iface"
-          break
-        fi
-      done
-      if [[ -z "$match_iface" ]]; then
-        match_iface=$(route -n get -inet "$probe_ip" 2>/dev/null | awk '/interface:/{print $2}')
-        [[ "$match_iface" == lo* ]] && match_iface=""
-      fi
-      if [[ -n "$match_iface" ]]; then
-        IFS=$'\t' read -r v6_cidr ipv4_addr < <(iface_ipv6_cidr "$match_iface") || v6_cidr=""
-      fi
-      if [[ -z "$v6_cidr" ]]; then
-        for iface in $(ifconfig -l 2>/dev/null); do
-          [[ "$iface" == lo* ]] && continue
-          if IFS=$'\t' read -r v6_cidr ipv4_addr < <(iface_ipv6_cidr "$iface"); then
-            ipv6_scan_iface="$iface"
-            break
-          fi
-        done
-      else
-        ipv6_scan_iface="$match_iface"
-      fi
-      ;;
-    Linux)
-      while IFS= read -r line; do
-        iface=$(awk '{print $2}' <<< "$line" | sed 's/:$//')
-        [[ "$iface" == lo* ]] && continue
-        ipv4_addr=$(awk '{print $4}' <<< "$line" | cut -d/ -f1)
-        if [[ -n "$ipv4_addr" && "$ipv4_addr" != "127.0.0.1" ]] && ipv4_in_subnet "$ipv4_addr" "$cidr"; then
-          match_iface="$iface"
-          break
-        fi
-      done < <(ip -4 -o addr show scope global 2>/dev/null)
-      if [[ -z "$match_iface" ]]; then
-        match_iface=$(ip route get "$probe_ip" 2>/dev/null | awk '/dev/{for(i=1;i<=NF;i++) if($i=="dev"){print $(i+1); exit}}')
-        [[ "$match_iface" == lo* ]] && match_iface=""
-      fi
-      if [[ -n "$match_iface" ]]; then
-        IFS=$'\t' read -r v6_cidr ipv4_addr < <(iface_ipv6_cidr "$match_iface") || v6_cidr=""
-      fi
-      if [[ -z "$v6_cidr" ]]; then
-        while IFS= read -r line; do
-          iface=$(awk '{print $2}' <<< "$line" | sed 's/:$//')
-          [[ "$iface" == lo* ]] && continue
-          if IFS=$'\t' read -r v6_cidr ipv4_addr < <(iface_ipv6_cidr "$iface"); then
-            ipv6_scan_iface="$iface"
-            break
-          fi
-        done < <(ip -6 -o addr show scope global 2>/dev/null)
-      else
-        ipv6_scan_iface="$match_iface"
-      fi
-      ;;
-  esac
+  if [[ -n "$ipv6_scan_iface" ]]; then
+    IFS=$'\t' read -r v6_cidr _ < <(iface_ipv6_cidr "$ipv6_scan_iface") || v6_cidr=""
+  fi
 
   if [[ -z "$v6_cidr" ]]; then
     return 1
@@ -238,7 +330,8 @@ find_local_ipv6_context() {
     vlan_digit=$(( target_vlan / 10 ))
   fi
   stem="${h4:0:$(( hextet_len - 1 ))}"
-  printf '%s\n' "${h1}:${h2}:${h3}:${stem}${vlan_digit}"
+  ipv6_prefix_from_map=false
+  ipv6_prefix64="${h1}:${h2}:${h3}:${stem}${vlan_digit}"
   return 0
 }
 
@@ -326,6 +419,7 @@ filter=""
 quiet=false
 dry_run=false
 scan_ipv6=false
+ipv6_prefix_from_map=false
 RECORD_FS=$'\x1e'
 
 # Parse command line arguments
@@ -359,6 +453,10 @@ while [[ $# -gt 0 ]]; do
       scan_ipv6=true
       shift
       ;;
+    --v6-map)
+      ipv6_map_file="$2"
+      shift 2
+      ;;
     -v|--version)
       echo "pingsweep $PINGSWEEP_VERSION"
       exit 0
@@ -373,6 +471,7 @@ while [[ $# -gt 0 ]]; do
       echo "  -n, --dry-run          Show IPs that would be scanned without scanning"
       echo "  -s, --search SEARCH   Search/filter output (supports substring, wildcards, or regex with re: prefix)"
       echo "      --v6              Parallel aligned IPv6 probes and DNS alignment checks (see README)"
+      echo "      --v6-map FILE     IPv4-CIDR to IPv6-/64 map file (overrides default paths)"
       echo "  -v, --version         Show version information"
       echo "  -h, --help            Show this help message"
       echo "Example: pingsweep 192.168.1.0/24"
@@ -394,6 +493,11 @@ check_requirements
 
 if [ "$scan_ipv6" = true ] && ! command -v dig >/dev/null 2>&1; then
   echo "Warning: 'dig' not found; --v6 will ping aligned addresses but skip DNS alignment checks." >&2
+fi
+
+if [[ -n "$ipv6_map_file" && ! -f "$ipv6_map_file" ]]; then
+  echo "Error: IPv6 map file not found: $ipv6_map_file" >&2
+  exit 1
 fi
 
 # Derive per-tool timeouts from the user-facing seconds value. dig's +time is
@@ -572,12 +676,12 @@ fi
 if [ "$dry_run" = true ]; then
   echo "Dry-run mode: IPs that would be scanned:"
   if [ "$scan_ipv6" = true ]; then
-    ipv6_prefix64=$(find_local_ipv6_context "$subnet") || {
+    if ! find_local_ipv6_context "$subnet"; then
       echo "Error: --v6 could not determine a local global IPv6 /64 for $subnet" >&2
       echo "Scan from a host with IPv4 and IPv6 on the target VLAN/subnet." >&2
       exit 1
-    }
-    echo "IPv6 prefix (from this host): ${ipv6_prefix64}::/64"
+    fi
+    echo "IPv6 prefix ($(if [ "$ipv6_prefix_from_map" = true ]; then echo configured; else echo auto-detected; fi)): ${ipv6_prefix64}::/64"
     while IFS= read -r ip; do
       echo "$ip  ->  $(aligned_ipv6_address "$ip" "$ipv6_prefix64")"
     done < "$results_file.ips"
@@ -591,13 +695,17 @@ fi
 
 ipv6_prefix64=""
 if [ "$scan_ipv6" = true ]; then
-  ipv6_prefix64=$(find_local_ipv6_context "$subnet") || {
+  if ! find_local_ipv6_context "$subnet"; then
     echo "Error: --v6 could not determine a local global IPv6 /64 for $subnet" >&2
     echo "Scan from a host with IPv4 and IPv6 on the target VLAN/subnet." >&2
     exit 1
-  }
+  fi
   if [[ "$format" == "text" ]] && [ "$quiet" = false ]; then
-    echo "IPv6 aligned prefix: ${ipv6_prefix64}::/64 (host-id = last IPv4 octet)" >&2
+    if [ "$ipv6_prefix_from_map" = true ]; then
+      echo "IPv6 aligned prefix: ${ipv6_prefix64}::/64 (from ipv6-map; host-id = last IPv4 octet)" >&2
+    else
+      echo "IPv6 aligned prefix: ${ipv6_prefix64}::/64 (host-id = last IPv4 octet)" >&2
+    fi
   fi
 fi
 


### PR DESCRIPTION
## Summary
- Fixes CI: unquoted `Usage:` in the help grep step was invalid YAML (colon parsed as mapping), causing every workflow run to fail with zero jobs
- Adds user-space IPv6 alignment maps for subnets that do not follow `10.0.VLAN.0/CIDR` auto-detection (e.g. VLAN 1 on `192.168.1.0/24` → `2601:441:8483:b500::/64`)
- Supports `--v6-map`, `$PINGSWEEP_IPV6_MAP`, and `~/.config/pingsweep/ipv6-map`; includes `examples/ipv6-map.example`

## Test plan
- [x] `bash -n pingsweep`
- [x] Ruby YAML parse of `.github/workflows/ci.yml`
- [x] `./pingsweep -n --v6 --v6-map examples/ipv6-map.example 192.168.1.0/30` shows configured `b500` prefix
- [x] `./pingsweep -n --v6 10.0.2.0/29` still auto-detects
- [ ] GitHub Actions validate job passes


Made with [Cursor](https://cursor.com)